### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 .travis.yml export-ignore
 composer.json export-ignore
 phpunit.xml export-ignore
+tests/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.gitreview export-ignore
+.travis.yml export-ignore
+composer.json export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Stops composer exporting files that aren't needed in vendor folders